### PR TITLE
Notifications: end-to-end in-app alerts, real-time push, and full notifications experience

### DIFF
--- a/SocialMedia.Application/DTOs/NotificationDTOs/NotificationDto.cs
+++ b/SocialMedia.Application/DTOs/NotificationDTOs/NotificationDto.cs
@@ -7,6 +7,7 @@ namespace SocialMedia.Application.DTOs.NotificationDTOs
         public Guid Id { get; set; }
         public NotificationType Type { get; set; }
         public string Content { get; set; } = string.Empty;
+        public string? ActionUrl { get; set; }
         public bool IsRead { get; set; }
         public DateTime CreatedAt { get; set; }
         public string? SenderId { get; set; }

--- a/SocialMedia.Application/DTOs/NotificationDTOs/NotificationDto.cs
+++ b/SocialMedia.Application/DTOs/NotificationDTOs/NotificationDto.cs
@@ -1,0 +1,16 @@
+using SocialMedia.Domain.Enums;
+
+namespace SocialMedia.Application.DTOs.NotificationDTOs
+{
+    public class NotificationDto
+    {
+        public Guid Id { get; set; }
+        public NotificationType Type { get; set; }
+        public string Content { get; set; } = string.Empty;
+        public bool IsRead { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string? SenderId { get; set; }
+        public string SenderName { get; set; } = "Unknown";
+        public string? SenderProfilePictureUrl { get; set; }
+    }
+}

--- a/SocialMedia.Application/Interfaces/IUnitOfWork.cs
+++ b/SocialMedia.Application/Interfaces/IUnitOfWork.cs
@@ -13,6 +13,7 @@ namespace SocialMedia.Application.Interfaces
         
         IMessageRepository Messages { get; }
         IGroupChatRepository GroupChats { get; }
+        INotificationRepository Notifications { get; }
 
         // ── User lookup — ApplicationUser extends IdentityUser, not BaseEntity,
         //    so it cannot go through Repository<T>. This method handles it directly.

--- a/SocialMedia.Application/Interfaces/Repositories/INotificationRepository.cs
+++ b/SocialMedia.Application/Interfaces/Repositories/INotificationRepository.cs
@@ -1,0 +1,12 @@
+using SocialMedia.Domain.Entities;
+
+namespace SocialMedia.Application.Interfaces.Repositories
+{
+    public interface INotificationRepository : IGenericRepository<Notification>
+    {
+        Task<IReadOnlyList<Notification>> GetForUserAsync(string userId, int skip, int take);
+        Task<int> GetUnreadCountAsync(string userId);
+        Task<Notification?> GetByIdForUserAsync(Guid notificationId, string userId);
+        Task<IReadOnlyList<Notification>> GetUnreadForUserAsync(string userId);
+    }
+}

--- a/SocialMedia.Application/Interfaces/Services/INotificationRealtimeService.cs
+++ b/SocialMedia.Application/Interfaces/Services/INotificationRealtimeService.cs
@@ -1,0 +1,9 @@
+using SocialMedia.Domain.Enums;
+
+namespace SocialMedia.Application.Interfaces.Services
+{
+    public interface INotificationRealtimeService
+    {
+        Task PushAsync(string targetUserId, NotificationType type, string message, string? actionUrl = null);
+    }
+}

--- a/SocialMedia.Application/Interfaces/Services/INotificationRealtimeService.cs
+++ b/SocialMedia.Application/Interfaces/Services/INotificationRealtimeService.cs
@@ -4,6 +4,12 @@ namespace SocialMedia.Application.Interfaces.Services
 {
     public interface INotificationRealtimeService
     {
-        Task PushAsync(string targetUserId, NotificationType type, string message, string? actionUrl = null);
+        Task PushAsync(
+            string targetUserId,
+            NotificationType type,
+            string message,
+            string? actionUrl = null,
+            Guid? notificationId = null,
+            DateTime? createdAt = null);
     }
 }

--- a/SocialMedia.Application/Interfaces/Services/INotificationService.cs
+++ b/SocialMedia.Application/Interfaces/Services/INotificationService.cs
@@ -1,0 +1,9 @@
+using SocialMedia.Application.DTOs.NotificationDTOs;
+
+namespace SocialMedia.Application.Interfaces.Services
+{
+    public interface INotificationService
+    {
+        Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20);
+    }
+}

--- a/SocialMedia.Application/Interfaces/Services/INotificationService.cs
+++ b/SocialMedia.Application/Interfaces/Services/INotificationService.cs
@@ -4,7 +4,7 @@ namespace SocialMedia.Application.Interfaces.Services
 {
     public interface INotificationService
     {
-        Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20);
+        Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20, int skip = 0);
         Task<int> GetUnreadCountAsync(string userId);
         Task<bool> MarkAsReadAsync(string userId, Guid notificationId);
         Task<int> MarkAllAsReadAsync(string userId);

--- a/SocialMedia.Application/Interfaces/Services/INotificationService.cs
+++ b/SocialMedia.Application/Interfaces/Services/INotificationService.cs
@@ -6,5 +6,6 @@ namespace SocialMedia.Application.Interfaces.Services
     {
         Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20);
         Task<bool> MarkAsReadAsync(string userId, Guid notificationId);
+        Task<int> MarkAllAsReadAsync(string userId);
     }
 }

--- a/SocialMedia.Application/Interfaces/Services/INotificationService.cs
+++ b/SocialMedia.Application/Interfaces/Services/INotificationService.cs
@@ -5,6 +5,7 @@ namespace SocialMedia.Application.Interfaces.Services
     public interface INotificationService
     {
         Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20);
+        Task<int> GetUnreadCountAsync(string userId);
         Task<bool> MarkAsReadAsync(string userId, Guid notificationId);
         Task<int> MarkAllAsReadAsync(string userId);
     }

--- a/SocialMedia.Application/Interfaces/Services/INotificationService.cs
+++ b/SocialMedia.Application/Interfaces/Services/INotificationService.cs
@@ -5,5 +5,6 @@ namespace SocialMedia.Application.Interfaces.Services
     public interface INotificationService
     {
         Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20);
+        Task<bool> MarkAsReadAsync(string userId, Guid notificationId);
     }
 }

--- a/SocialMedia.Application/Services/CommentService.cs
+++ b/SocialMedia.Application/Services/CommentService.cs
@@ -71,10 +71,12 @@ namespace SocialMedia.Application.Services
                 await _uow.CompleteAsync();
                 try
                 {
+                    var actionUrl = $"/Home/Index#post-{dto.PostId}";
                     await _notificationRealtimeService.PushAsync(
                         post.UserId,
                         NotificationType.Comment,
                         message,
+                        actionUrl: actionUrl,
                         notificationId: notification.Id,
                         createdAt: notification.CreatedAt);
                 }

--- a/SocialMedia.Application/Services/CommentService.cs
+++ b/SocialMedia.Application/Services/CommentService.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using SocialMedia.Application.DTOs.PostDtos.CommentDtos;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Application.Interfaces.Services;
 using SocialMedia.Domain.Entities;
+using SocialMedia.Domain.Enums;
 
 namespace SocialMedia.Application.Services
 {
@@ -30,6 +31,9 @@ namespace SocialMedia.Application.Services
 
         public async Task<CommentDto> AddCommentAsync(CreateCommentDto dto, string userId)
         {
+            var post = await _uow.Repository<Post>().GetByIdAsync(dto.PostId)
+                ?? throw new KeyNotFoundException("Post not found.");
+
             var comment = new Comment
             {
                 Content = dto.Content,
@@ -39,6 +43,21 @@ namespace SocialMedia.Application.Services
             };
 
             await _uow.Repository<Comment>().AddAsync(comment);
+
+            if (post.UserId != userId)
+            {
+                var sender = await _uow.FindUserByIdAsync(userId);
+                var senderName = sender?.UserName ?? "Someone";
+
+                await _uow.Repository<Notification>().AddAsync(new Notification
+                {
+                    UserId = post.UserId,
+                    SenderId = userId,
+                    Type = NotificationType.Comment,
+                    Content = $"{senderName} commented on your post."
+                });
+            }
+
             await _uow.CompleteAsync();
 
             // Re-query to eager-load User for the returned DTO

--- a/SocialMedia.Application/Services/CommentService.cs
+++ b/SocialMedia.Application/Services/CommentService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using SocialMedia.Application.DTOs.PostDtos.CommentDtos;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Application.Interfaces.Services;
@@ -11,11 +12,16 @@ namespace SocialMedia.Application.Services
     {
         private readonly IUnitOfWork _uow;
         private readonly INotificationRealtimeService _notificationRealtimeService;
+        private readonly ILogger<CommentService> _logger;
 
-        public CommentService(IUnitOfWork uow, INotificationRealtimeService notificationRealtimeService)
+        public CommentService(
+            IUnitOfWork uow,
+            INotificationRealtimeService notificationRealtimeService,
+            ILogger<CommentService> logger)
         {
             _uow = uow;
             _notificationRealtimeService = notificationRealtimeService;
+            _logger = logger;
         }
 
         public async Task<List<CommentDto>> GetPostCommentsAsync(Guid postId)
@@ -61,10 +67,20 @@ namespace SocialMedia.Application.Services
                 });
 
                 await _uow.CompleteAsync();
-                await _notificationRealtimeService.PushAsync(
-                    post.UserId,
-                    NotificationType.Comment,
-                    message);
+                try
+                {
+                    await _notificationRealtimeService.PushAsync(
+                        post.UserId,
+                        NotificationType.Comment,
+                        message);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to push realtime comment notification. TargetUserId: {TargetUserId}",
+                        post.UserId);
+                }
             }
             else
             {

--- a/SocialMedia.Application/Services/CommentService.cs
+++ b/SocialMedia.Application/Services/CommentService.cs
@@ -10,10 +10,12 @@ namespace SocialMedia.Application.Services
     public class CommentService : ICommentService
     {
         private readonly IUnitOfWork _uow;
+        private readonly INotificationRealtimeService _notificationRealtimeService;
 
-        public CommentService(IUnitOfWork uow)
+        public CommentService(IUnitOfWork uow, INotificationRealtimeService notificationRealtimeService)
         {
             _uow = uow;
+            _notificationRealtimeService = notificationRealtimeService;
         }
 
         public async Task<List<CommentDto>> GetPostCommentsAsync(Guid postId)
@@ -48,17 +50,26 @@ namespace SocialMedia.Application.Services
             {
                 var sender = await _uow.FindUserByIdAsync(userId);
                 var senderName = sender?.UserName ?? "Someone";
+                var message = $"{senderName} commented on your post.";
 
                 await _uow.Repository<Notification>().AddAsync(new Notification
                 {
                     UserId = post.UserId,
                     SenderId = userId,
                     Type = NotificationType.Comment,
-                    Content = $"{senderName} commented on your post."
+                    Content = message
                 });
-            }
 
-            await _uow.CompleteAsync();
+                await _uow.CompleteAsync();
+                await _notificationRealtimeService.PushAsync(
+                    post.UserId,
+                    NotificationType.Comment,
+                    message);
+            }
+            else
+            {
+                await _uow.CompleteAsync();
+            }
 
             // Re-query to eager-load User for the returned DTO
             var saved = await _uow.Repository<Comment>()

--- a/SocialMedia.Application/Services/CommentService.cs
+++ b/SocialMedia.Application/Services/CommentService.cs
@@ -58,13 +58,15 @@ namespace SocialMedia.Application.Services
                 var senderName = sender?.UserName ?? "Someone";
                 var message = $"{senderName} commented on your post.";
 
-                await _uow.Repository<Notification>().AddAsync(new Notification
+                var notification = new Notification
                 {
                     UserId = post.UserId,
                     SenderId = userId,
                     Type = NotificationType.Comment,
                     Content = message
-                });
+                };
+
+                await _uow.Repository<Notification>().AddAsync(notification);
 
                 await _uow.CompleteAsync();
                 try
@@ -72,7 +74,9 @@ namespace SocialMedia.Application.Services
                     await _notificationRealtimeService.PushAsync(
                         post.UserId,
                         NotificationType.Comment,
-                        message);
+                        message,
+                        notificationId: notification.Id,
+                        createdAt: notification.CreatedAt);
                 }
                 catch (Exception ex)
                 {

--- a/SocialMedia.Application/Services/FriendshipService.cs
+++ b/SocialMedia.Application/Services/FriendshipService.cs
@@ -57,14 +57,17 @@ namespace SocialMedia.Application.Services
 
             var sender = await _unitOfWork.FindUserByIdAsync(senderId);
             var senderName = sender?.UserName ?? "Someone";
+            var notificationMessage = $"{senderName} sent you a follow request.";
 
-            await _unitOfWork.Repository<Notification>().AddAsync(new Notification
+            var notification = new Notification
             {
                 UserId = receiverId,
                 SenderId = senderId,
                 Type = NotificationType.FriendRequest,
-                Content = $"{senderName} sent you a follow request."
-            });
+                Content = notificationMessage
+            };
+
+            await _unitOfWork.Repository<Notification>().AddAsync(notification);
 
             var saved = await _unitOfWork.CompleteAsync() > 0;
             if (saved)
@@ -74,7 +77,9 @@ namespace SocialMedia.Application.Services
                     await _notificationRealtimeService.PushAsync(
                         receiverId,
                         NotificationType.FriendRequest,
-                        $"{senderName} sent you a follow request.");
+                        notificationMessage,
+                        notificationId: notification.Id,
+                        createdAt: notification.CreatedAt);
                 }
                 catch (Exception ex)
                 {

--- a/SocialMedia.Application/Services/FriendshipService.cs
+++ b/SocialMedia.Application/Services/FriendshipService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Domain.Entities;
 using SocialMedia.Domain.Enums;
@@ -20,17 +21,20 @@ namespace SocialMedia.Application.Services
         private readonly IUnitOfWork _unitOfWork;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly INotificationRealtimeService _notificationRealtimeService;
+        private readonly ILogger<FriendshipService> _logger;
 
         public FriendshipService(
             IFriendshipRepository friendshipRepository,
             IUnitOfWork unitOfWork,
             UserManager<ApplicationUser> userManager,
-            INotificationRealtimeService notificationRealtimeService)
+            INotificationRealtimeService notificationRealtimeService,
+            ILogger<FriendshipService> logger)
         {
             _friendshipRepository = friendshipRepository;
             _unitOfWork = unitOfWork;
             _userManager = userManager;
             _notificationRealtimeService = notificationRealtimeService;
+            _logger = logger;
         }
 
         public async Task<bool> SendRequestAsync(string senderId, string receiverId)
@@ -65,10 +69,20 @@ namespace SocialMedia.Application.Services
             var saved = await _unitOfWork.CompleteAsync() > 0;
             if (saved)
             {
-                await _notificationRealtimeService.PushAsync(
-                    receiverId,
-                    NotificationType.FriendRequest,
-                    $"{senderName} sent you a follow request.");
+                try
+                {
+                    await _notificationRealtimeService.PushAsync(
+                        receiverId,
+                        NotificationType.FriendRequest,
+                        $"{senderName} sent you a follow request.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to push realtime follow notification. TargetUserId: {TargetUserId}",
+                        receiverId);
+                }
             }
 
             return saved;

--- a/SocialMedia.Application/Services/FriendshipService.cs
+++ b/SocialMedia.Application/Services/FriendshipService.cs
@@ -44,6 +44,18 @@ namespace SocialMedia.Application.Services
             };
 
             await _friendshipRepository.AddAsync(friendship);
+
+            var sender = await _unitOfWork.FindUserByIdAsync(senderId);
+            var senderName = sender?.UserName ?? "Someone";
+
+            await _unitOfWork.Repository<Notification>().AddAsync(new Notification
+            {
+                UserId = receiverId,
+                SenderId = senderId,
+                Type = NotificationType.FriendRequest,
+                Content = $"{senderName} sent you a follow request."
+            });
+
             return await _unitOfWork.CompleteAsync() > 0;
         }
 

--- a/SocialMedia.Application/Services/FriendshipService.cs
+++ b/SocialMedia.Application/Services/FriendshipService.cs
@@ -74,10 +74,12 @@ namespace SocialMedia.Application.Services
             {
                 try
                 {
+                    var actionUrl = $"/Profile/Index?id={senderId}";
                     await _notificationRealtimeService.PushAsync(
                         receiverId,
                         NotificationType.FriendRequest,
                         notificationMessage,
+                        actionUrl: actionUrl,
                         notificationId: notification.Id,
                         createdAt: notification.CreatedAt);
                 }

--- a/SocialMedia.Application/Services/FriendshipService.cs
+++ b/SocialMedia.Application/Services/FriendshipService.cs
@@ -19,12 +19,18 @@ namespace SocialMedia.Application.Services
         private readonly IFriendshipRepository _friendshipRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly INotificationRealtimeService _notificationRealtimeService;
 
-        public FriendshipService(IFriendshipRepository friendshipRepository, IUnitOfWork unitOfWork, UserManager<ApplicationUser> userManager)
+        public FriendshipService(
+            IFriendshipRepository friendshipRepository,
+            IUnitOfWork unitOfWork,
+            UserManager<ApplicationUser> userManager,
+            INotificationRealtimeService notificationRealtimeService)
         {
             _friendshipRepository = friendshipRepository;
             _unitOfWork = unitOfWork;
             _userManager = userManager;
+            _notificationRealtimeService = notificationRealtimeService;
         }
 
         public async Task<bool> SendRequestAsync(string senderId, string receiverId)
@@ -56,7 +62,16 @@ namespace SocialMedia.Application.Services
                 Content = $"{senderName} sent you a follow request."
             });
 
-            return await _unitOfWork.CompleteAsync() > 0;
+            var saved = await _unitOfWork.CompleteAsync() > 0;
+            if (saved)
+            {
+                await _notificationRealtimeService.PushAsync(
+                    receiverId,
+                    NotificationType.FriendRequest,
+                    $"{senderName} sent you a follow request.");
+            }
+
+            return saved;
         }
 
         public async Task<bool> AcceptRequestAsync(string receiverId, string senderId)

--- a/SocialMedia.Application/Services/MessageService.cs
+++ b/SocialMedia.Application/Services/MessageService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using SocialMedia.Application.DTOs.ChatDTOs;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Application.Interfaces.Services;
@@ -14,11 +15,16 @@ namespace SocialMedia.Application.Services
     {
         private readonly IUnitOfWork _uow;
         private readonly INotificationRealtimeService _notificationRealtimeService;
+        private readonly ILogger<MessageService> _logger;
 
-        public MessageService(IUnitOfWork uow, INotificationRealtimeService notificationRealtimeService)
+        public MessageService(
+            IUnitOfWork uow,
+            INotificationRealtimeService notificationRealtimeService,
+            ILogger<MessageService> logger)
         {
             _uow = uow;
             _notificationRealtimeService = notificationRealtimeService;
+            _logger = logger;
         }
 
         // ── Send ──────────────────────────────────────────────────────────────
@@ -55,10 +61,20 @@ namespace SocialMedia.Application.Services
 
             if (senderId != dto.ReceiverId)
             {
-                await _notificationRealtimeService.PushAsync(
-                    dto.ReceiverId,
-                    NotificationType.Message,
-                    notificationMessage);
+                try
+                {
+                    await _notificationRealtimeService.PushAsync(
+                        dto.ReceiverId,
+                        NotificationType.Message,
+                        notificationMessage);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to push realtime message notification. TargetUserId: {TargetUserId}",
+                        dto.ReceiverId);
+                }
             }
 
             return MapToDto(message, sender);

--- a/SocialMedia.Application/Services/MessageService.cs
+++ b/SocialMedia.Application/Services/MessageService.cs
@@ -13,10 +13,12 @@ namespace SocialMedia.Application.Services
     public class MessageService : IMessageService
     {
         private readonly IUnitOfWork _uow;
+        private readonly INotificationRealtimeService _notificationRealtimeService;
 
-        public MessageService(IUnitOfWork uow)
+        public MessageService(IUnitOfWork uow, INotificationRealtimeService notificationRealtimeService)
         {
             _uow = uow;
+            _notificationRealtimeService = notificationRealtimeService;
         }
 
         // ── Send ──────────────────────────────────────────────────────────────
@@ -36,6 +38,7 @@ namespace SocialMedia.Application.Services
             // ApplicationUser is not a BaseEntity so we use FindUserByIdAsync, not Repository<T>
             var sender = await _uow.FindUserByIdAsync(senderId);
             var senderName = sender?.UserName ?? "Someone";
+            var notificationMessage = $"{senderName} sent you a message.";
 
             if (senderId != dto.ReceiverId)
             {
@@ -44,11 +47,19 @@ namespace SocialMedia.Application.Services
                     UserId = dto.ReceiverId,
                     SenderId = senderId,
                     Type = NotificationType.Message,
-                    Content = $"{senderName} sent you a message."
+                    Content = notificationMessage
                 });
             }
 
             await _uow.CompleteAsync();
+
+            if (senderId != dto.ReceiverId)
+            {
+                await _notificationRealtimeService.PushAsync(
+                    dto.ReceiverId,
+                    NotificationType.Message,
+                    notificationMessage);
+            }
 
             return MapToDto(message, sender);
         }

--- a/SocialMedia.Application/Services/MessageService.cs
+++ b/SocialMedia.Application/Services/MessageService.cs
@@ -2,6 +2,7 @@ using SocialMedia.Application.DTOs.ChatDTOs;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Application.Interfaces.Services;
 using SocialMedia.Domain.Entities;
+using SocialMedia.Domain.Enums;
 
 namespace SocialMedia.Application.Services
 {
@@ -31,10 +32,23 @@ namespace SocialMedia.Application.Services
             };
 
             await _uow.Messages.AddAsync(message);
-            await _uow.CompleteAsync();
 
             // ApplicationUser is not a BaseEntity so we use FindUserByIdAsync, not Repository<T>
             var sender = await _uow.FindUserByIdAsync(senderId);
+            var senderName = sender?.UserName ?? "Someone";
+
+            if (senderId != dto.ReceiverId)
+            {
+                await _uow.Repository<Notification>().AddAsync(new Notification
+                {
+                    UserId = dto.ReceiverId,
+                    SenderId = senderId,
+                    Type = NotificationType.Message,
+                    Content = $"{senderName} sent you a message."
+                });
+            }
+
+            await _uow.CompleteAsync();
 
             return MapToDto(message, sender);
         }

--- a/SocialMedia.Application/Services/MessageService.cs
+++ b/SocialMedia.Application/Services/MessageService.cs
@@ -45,16 +45,19 @@ namespace SocialMedia.Application.Services
             var sender = await _uow.FindUserByIdAsync(senderId);
             var senderName = sender?.UserName ?? "Someone";
             var notificationMessage = $"{senderName} sent you a message.";
+            Notification? notification = null;
 
             if (senderId != dto.ReceiverId)
             {
-                await _uow.Repository<Notification>().AddAsync(new Notification
+                notification = new Notification
                 {
                     UserId = dto.ReceiverId,
                     SenderId = senderId,
                     Type = NotificationType.Message,
                     Content = notificationMessage
-                });
+                };
+
+                await _uow.Repository<Notification>().AddAsync(notification);
             }
 
             await _uow.CompleteAsync();
@@ -66,7 +69,9 @@ namespace SocialMedia.Application.Services
                     await _notificationRealtimeService.PushAsync(
                         dto.ReceiverId,
                         NotificationType.Message,
-                        notificationMessage);
+                        notificationMessage,
+                        notificationId: notification?.Id,
+                        createdAt: notification?.CreatedAt);
                 }
                 catch (Exception ex)
                 {

--- a/SocialMedia.Application/Services/MessageService.cs
+++ b/SocialMedia.Application/Services/MessageService.cs
@@ -66,10 +66,12 @@ namespace SocialMedia.Application.Services
             {
                 try
                 {
+                    var actionUrl = $"/Messaging/Chat?otherUserId={senderId}";
                     await _notificationRealtimeService.PushAsync(
                         dto.ReceiverId,
                         NotificationType.Message,
                         notificationMessage,
+                        actionUrl: actionUrl,
                         notificationId: notification?.Id,
                         createdAt: notification?.CreatedAt);
                 }

--- a/SocialMedia.Application/Services/NotificationService.cs
+++ b/SocialMedia.Application/Services/NotificationService.cs
@@ -2,6 +2,7 @@ using SocialMedia.Application.DTOs.NotificationDTOs;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Application.Interfaces.Services;
 using SocialMedia.Domain.Entities;
+using SocialMedia.Domain.Enums;
 
 namespace SocialMedia.Application.Services
 {
@@ -28,6 +29,7 @@ namespace SocialMedia.Application.Services
                     Id = n.Id,
                     Type = n.Type,
                     Content = n.Content,
+                    ActionUrl = BuildActionUrl(n.Type, n.SenderId),
                     IsRead = n.IsRead,
                     CreatedAt = n.CreatedAt,
                     SenderId = n.SenderId,
@@ -77,6 +79,24 @@ namespace SocialMedia.Application.Services
 
             await _uow.CompleteAsync();
             return unreadNotifications.Count;
+        }
+
+        private static string BuildActionUrl(NotificationType type, string? senderId)
+        {
+            return type switch
+            {
+                NotificationType.Message when !string.IsNullOrWhiteSpace(senderId)
+                    => $"/Messaging/Chat?otherUserId={senderId}",
+                NotificationType.FriendRequest when !string.IsNullOrWhiteSpace(senderId)
+                    => $"/Profile/Index?id={senderId}",
+                NotificationType.PostReaction
+                    => "/Home/Index",
+                NotificationType.Comment
+                    => "/Home/Index",
+                NotificationType.GroupInvitation
+                    => "/GroupChat/Index",
+                _ => "/Home/Index"
+            };
         }
     }
 }

--- a/SocialMedia.Application/Services/NotificationService.cs
+++ b/SocialMedia.Application/Services/NotificationService.cs
@@ -41,5 +41,24 @@ namespace SocialMedia.Application.Services
 
             return notifications;
         }
+
+        public async Task<bool> MarkAsReadAsync(string userId, Guid notificationId)
+        {
+            var notification = await _uow.Repository<Notification>()
+                .Query()
+                .FirstOrDefaultAsync(n => n.Id == notificationId && n.UserId == userId);
+
+            if (notification == null)
+                return false;
+
+            if (notification.IsRead)
+                return true;
+
+            notification.IsRead = true;
+            notification.UpdatedAt = DateTime.UtcNow;
+            _uow.Repository<Notification>().Update(notification);
+
+            return await _uow.CompleteAsync() > 0;
+        }
     }
 }

--- a/SocialMedia.Application/Services/NotificationService.cs
+++ b/SocialMedia.Application/Services/NotificationService.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using SocialMedia.Application.DTOs.NotificationDTOs;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Application.Interfaces.Services;
@@ -15,17 +14,15 @@ namespace SocialMedia.Application.Services
             _uow = uow;
         }
 
-        public async Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20)
+        public async Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20, int skip = 0)
         {
             if (take <= 0) take = 20;
             if (take > 100) take = 100;
+            if (skip < 0) skip = 0;
 
-            var notifications = await _uow.Repository<Notification>()
-                .Query()
-                .Where(n => n.UserId == userId)
-                .Include(n => n.Sender)
-                .OrderByDescending(n => n.CreatedAt)
-                .Take(take)
+            var notifications = await _uow.Notifications.GetForUserAsync(userId, skip, take);
+
+            return notifications
                 .Select(n => new NotificationDto
                 {
                     Id = n.Id,
@@ -37,23 +34,17 @@ namespace SocialMedia.Application.Services
                     SenderName = n.Sender != null ? (n.Sender.UserName ?? "Unknown") : "Unknown",
                     SenderProfilePictureUrl = n.Sender != null ? n.Sender.ProfilePictureUrl : null
                 })
-                .ToListAsync();
-
-            return notifications;
+                .ToList();
         }
 
         public async Task<int> GetUnreadCountAsync(string userId)
         {
-            return await _uow.Repository<Notification>()
-                .Query()
-                .CountAsync(n => n.UserId == userId && !n.IsRead);
+            return await _uow.Notifications.GetUnreadCountAsync(userId);
         }
 
         public async Task<bool> MarkAsReadAsync(string userId, Guid notificationId)
         {
-            var notification = await _uow.Repository<Notification>()
-                .Query()
-                .FirstOrDefaultAsync(n => n.Id == notificationId && n.UserId == userId);
+            var notification = await _uow.Notifications.GetByIdForUserAsync(notificationId, userId);
 
             if (notification == null)
                 return false;
@@ -63,29 +54,25 @@ namespace SocialMedia.Application.Services
 
             notification.IsRead = true;
             notification.UpdatedAt = DateTime.UtcNow;
-            _uow.Repository<Notification>().Update(notification);
+            _uow.Notifications.Update(notification);
 
             return await _uow.CompleteAsync() > 0;
         }
 
         public async Task<int> MarkAllAsReadAsync(string userId)
         {
-            var unreadNotifications = await _uow.Repository<Notification>()
-                .Query()
-                .Where(n => n.UserId == userId && !n.IsRead)
-                .ToListAsync();
+            var unreadNotifications = await _uow.Notifications.GetUnreadForUserAsync(userId);
 
             if (unreadNotifications.Count == 0)
                 return 0;
 
             var now = DateTime.UtcNow;
-            var repo = _uow.Repository<Notification>();
 
             foreach (var notification in unreadNotifications)
             {
                 notification.IsRead = true;
                 notification.UpdatedAt = now;
-                repo.Update(notification);
+                _uow.Notifications.Update(notification);
             }
 
             await _uow.CompleteAsync();

--- a/SocialMedia.Application/Services/NotificationService.cs
+++ b/SocialMedia.Application/Services/NotificationService.cs
@@ -60,5 +60,29 @@ namespace SocialMedia.Application.Services
 
             return await _uow.CompleteAsync() > 0;
         }
+
+        public async Task<int> MarkAllAsReadAsync(string userId)
+        {
+            var unreadNotifications = await _uow.Repository<Notification>()
+                .Query()
+                .Where(n => n.UserId == userId && !n.IsRead)
+                .ToListAsync();
+
+            if (unreadNotifications.Count == 0)
+                return 0;
+
+            var now = DateTime.UtcNow;
+            var repo = _uow.Repository<Notification>();
+
+            foreach (var notification in unreadNotifications)
+            {
+                notification.IsRead = true;
+                notification.UpdatedAt = now;
+                repo.Update(notification);
+            }
+
+            await _uow.CompleteAsync();
+            return unreadNotifications.Count;
+        }
     }
 }

--- a/SocialMedia.Application/Services/NotificationService.cs
+++ b/SocialMedia.Application/Services/NotificationService.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using SocialMedia.Application.DTOs.NotificationDTOs;
+using SocialMedia.Application.Interfaces;
+using SocialMedia.Application.Interfaces.Services;
+using SocialMedia.Domain.Entities;
+
+namespace SocialMedia.Application.Services
+{
+    public class NotificationService : INotificationService
+    {
+        private readonly IUnitOfWork _uow;
+
+        public NotificationService(IUnitOfWork uow)
+        {
+            _uow = uow;
+        }
+
+        public async Task<IReadOnlyList<NotificationDto>> GetUserNotificationsAsync(string userId, int take = 20)
+        {
+            if (take <= 0) take = 20;
+            if (take > 100) take = 100;
+
+            var notifications = await _uow.Repository<Notification>()
+                .Query()
+                .Where(n => n.UserId == userId)
+                .Include(n => n.Sender)
+                .OrderByDescending(n => n.CreatedAt)
+                .Take(take)
+                .Select(n => new NotificationDto
+                {
+                    Id = n.Id,
+                    Type = n.Type,
+                    Content = n.Content,
+                    IsRead = n.IsRead,
+                    CreatedAt = n.CreatedAt,
+                    SenderId = n.SenderId,
+                    SenderName = n.Sender != null ? (n.Sender.UserName ?? "Unknown") : "Unknown",
+                    SenderProfilePictureUrl = n.Sender != null ? n.Sender.ProfilePictureUrl : null
+                })
+                .ToListAsync();
+
+            return notifications;
+        }
+    }
+}

--- a/SocialMedia.Application/Services/NotificationService.cs
+++ b/SocialMedia.Application/Services/NotificationService.cs
@@ -42,6 +42,13 @@ namespace SocialMedia.Application.Services
             return notifications;
         }
 
+        public async Task<int> GetUnreadCountAsync(string userId)
+        {
+            return await _uow.Repository<Notification>()
+                .Query()
+                .CountAsync(n => n.UserId == userId && !n.IsRead);
+        }
+
         public async Task<bool> MarkAsReadAsync(string userId, Guid notificationId)
         {
             var notification = await _uow.Repository<Notification>()

--- a/SocialMedia.Application/Services/ReactionService.cs
+++ b/SocialMedia.Application/Services/ReactionService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using SocialMedia.Application.Interfaces;
 using SocialMedia.Application.Interfaces.Services;
 using SocialMedia.Domain.Entities;
@@ -14,13 +15,16 @@ namespace SocialMedia.Application.Services
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly INotificationRealtimeService _notificationRealtimeService;
+        private readonly ILogger<ReactionService> _logger;
 
         public ReactionService(
             IUnitOfWork unitOfWork,
-            INotificationRealtimeService notificationRealtimeService)
+            INotificationRealtimeService notificationRealtimeService,
+            ILogger<ReactionService> logger)
         {
             _unitOfWork = unitOfWork;
             _notificationRealtimeService = notificationRealtimeService;
+            _logger = logger;
         }
 
         public async Task AddOrUpdateReactionAsync(Guid postId, string userId, MultiReaction reaction)
@@ -67,10 +71,20 @@ namespace SocialMedia.Application.Services
                     });
 
                     await _unitOfWork.CompleteAsync();
-                    await _notificationRealtimeService.PushAsync(
-                        post.UserId,
-                        NotificationType.PostReaction,
-                        message);
+                    try
+                    {
+                        await _notificationRealtimeService.PushAsync(
+                            post.UserId,
+                            NotificationType.PostReaction,
+                            message);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Failed to push realtime reaction notification. TargetUserId: {TargetUserId}",
+                            post.UserId);
+                    }
                     return;
                 }
             }

--- a/SocialMedia.Application/Services/ReactionService.cs
+++ b/SocialMedia.Application/Services/ReactionService.cs
@@ -13,10 +13,14 @@ namespace SocialMedia.Application.Services
     public class ReactionService : IReactionService
     {
         private readonly IUnitOfWork _unitOfWork;
+        private readonly INotificationRealtimeService _notificationRealtimeService;
 
-        public ReactionService(IUnitOfWork unitOfWork)
+        public ReactionService(
+            IUnitOfWork unitOfWork,
+            INotificationRealtimeService notificationRealtimeService)
         {
             _unitOfWork = unitOfWork;
+            _notificationRealtimeService = notificationRealtimeService;
         }
 
         public async Task AddOrUpdateReactionAsync(Guid postId, string userId, MultiReaction reaction)
@@ -52,14 +56,22 @@ namespace SocialMedia.Application.Services
                 {
                     var sender = await _unitOfWork.FindUserByIdAsync(userId);
                     var senderName = sender?.UserName ?? "Someone";
+                    var message = $"{senderName} reacted to your post.";
 
                     await _unitOfWork.Repository<Notification>().AddAsync(new Notification
                     {
                         UserId = post.UserId,
                         SenderId = userId,
                         Type = NotificationType.PostReaction,
-                        Content = $"{senderName} reacted to your post."
+                        Content = message
                     });
+
+                    await _unitOfWork.CompleteAsync();
+                    await _notificationRealtimeService.PushAsync(
+                        post.UserId,
+                        NotificationType.PostReaction,
+                        message);
+                    return;
                 }
             }
 

--- a/SocialMedia.Application/Services/ReactionService.cs
+++ b/SocialMedia.Application/Services/ReactionService.cs
@@ -75,10 +75,12 @@ namespace SocialMedia.Application.Services
                     await _unitOfWork.CompleteAsync();
                     try
                     {
+                        var actionUrl = $"/Home/Index#post-{postId}";
                         await _notificationRealtimeService.PushAsync(
                             post.UserId,
                             NotificationType.PostReaction,
                             message,
+                            actionUrl: actionUrl,
                             notificationId: notification.Id,
                             createdAt: notification.CreatedAt);
                     }

--- a/SocialMedia.Application/Services/ReactionService.cs
+++ b/SocialMedia.Application/Services/ReactionService.cs
@@ -62,13 +62,15 @@ namespace SocialMedia.Application.Services
                     var senderName = sender?.UserName ?? "Someone";
                     var message = $"{senderName} reacted to your post.";
 
-                    await _unitOfWork.Repository<Notification>().AddAsync(new Notification
+                    var notification = new Notification
                     {
                         UserId = post.UserId,
                         SenderId = userId,
                         Type = NotificationType.PostReaction,
                         Content = message
-                    });
+                    };
+
+                    await _unitOfWork.Repository<Notification>().AddAsync(notification);
 
                     await _unitOfWork.CompleteAsync();
                     try
@@ -76,7 +78,9 @@ namespace SocialMedia.Application.Services
                         await _notificationRealtimeService.PushAsync(
                             post.UserId,
                             NotificationType.PostReaction,
-                            message);
+                            message,
+                            notificationId: notification.Id,
+                            createdAt: notification.CreatedAt);
                     }
                     catch (Exception ex)
                     {

--- a/SocialMedia.Application/Services/ReactionService.cs
+++ b/SocialMedia.Application/Services/ReactionService.cs
@@ -47,6 +47,20 @@ namespace SocialMedia.Application.Services
                 };
 
                 await repo.AddAsync(newReaction);
+
+                if (post.UserId != userId)
+                {
+                    var sender = await _unitOfWork.FindUserByIdAsync(userId);
+                    var senderName = sender?.UserName ?? "Someone";
+
+                    await _unitOfWork.Repository<Notification>().AddAsync(new Notification
+                    {
+                        UserId = post.UserId,
+                        SenderId = userId,
+                        Type = NotificationType.PostReaction,
+                        Content = $"{senderName} reacted to your post."
+                    });
+                }
             }
 
             await _unitOfWork.CompleteAsync();

--- a/SocialMedia.Infrastructure/Data/UnitOfWork.cs
+++ b/SocialMedia.Infrastructure/Data/UnitOfWork.cs
@@ -15,6 +15,7 @@ namespace SocialMedia.Infrastructure.Data
         // ── Dev4 custom repos — lazy-initialised ─────────────────────────────
         private IMessageRepository? _messages;
         private IGroupChatRepository? _groupChats;
+        private INotificationRepository? _notifications;
 
         public UnitOfWork(AppDbContext context)
         {
@@ -27,6 +28,9 @@ namespace SocialMedia.Infrastructure.Data
 
         public IGroupChatRepository GroupChats
             => _groupChats ??= new GroupChatRepository(_context);
+
+        public INotificationRepository Notifications
+            => _notifications ??= new NotificationRepository(_context);
 
         // ── Generic repo (BaseEntity descendants only) ────────────────────────
         public IGenericRepository<T> Repository<T>() where T : BaseEntity

--- a/SocialMedia.Infrastructure/Repositories/NotificationRepository.cs
+++ b/SocialMedia.Infrastructure/Repositories/NotificationRepository.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using SocialMedia.Application.Interfaces.Repositories;
+using SocialMedia.Domain.Entities;
+using SocialMedia.Infrastructure.Data;
+
+namespace SocialMedia.Infrastructure.Repositories
+{
+    public class NotificationRepository : Repository<Notification>, INotificationRepository
+    {
+        public NotificationRepository(AppDbContext context) : base(context)
+        {
+        }
+
+        public async Task<IReadOnlyList<Notification>> GetForUserAsync(string userId, int skip, int take)
+        {
+            return await _context.Set<Notification>()
+                .Where(n => n.UserId == userId)
+                .Include(n => n.Sender)
+                .OrderByDescending(n => n.CreatedAt)
+                .Skip(skip)
+                .Take(take)
+                .ToListAsync();
+        }
+
+        public async Task<int> GetUnreadCountAsync(string userId)
+        {
+            return await _context.Set<Notification>()
+                .CountAsync(n => n.UserId == userId && !n.IsRead);
+        }
+
+        public async Task<Notification?> GetByIdForUserAsync(Guid notificationId, string userId)
+        {
+            return await _context.Set<Notification>()
+                .FirstOrDefaultAsync(n => n.Id == notificationId && n.UserId == userId);
+        }
+
+        public async Task<IReadOnlyList<Notification>> GetUnreadForUserAsync(string userId)
+        {
+            return await _context.Set<Notification>()
+                .Where(n => n.UserId == userId && !n.IsRead)
+                .ToListAsync();
+        }
+    }
+}

--- a/SocialMedia.Web/Controllers/NotificationsController.cs
+++ b/SocialMedia.Web/Controllers/NotificationsController.cs
@@ -16,6 +16,12 @@ namespace SocialMedia.Web.Controllers
         }
 
         [HttpGet]
+        public IActionResult Index()
+        {
+            return View();
+        }
+
+        [HttpGet]
         public async Task<IActionResult> List(int take = 20, int skip = 0)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);

--- a/SocialMedia.Web/Controllers/NotificationsController.cs
+++ b/SocialMedia.Web/Controllers/NotificationsController.cs
@@ -16,12 +16,12 @@ namespace SocialMedia.Web.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> List(int take = 20)
+        public async Task<IActionResult> List(int take = 20, int skip = 0)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (userId == null) return Unauthorized();
 
-            var notifications = await _notificationService.GetUserNotificationsAsync(userId, take);
+            var notifications = await _notificationService.GetUserNotificationsAsync(userId, take, skip);
             return Ok(notifications);
         }
 

--- a/SocialMedia.Web/Controllers/NotificationsController.cs
+++ b/SocialMedia.Web/Controllers/NotificationsController.cs
@@ -25,6 +25,16 @@ namespace SocialMedia.Web.Controllers
             return Ok(notifications);
         }
 
+        [HttpGet]
+        public async Task<IActionResult> UnreadCount()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var count = await _notificationService.GetUnreadCountAsync(userId);
+            return Ok(new { count });
+        }
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> MarkAsRead(Guid id)

--- a/SocialMedia.Web/Controllers/NotificationsController.cs
+++ b/SocialMedia.Web/Controllers/NotificationsController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SocialMedia.Application.Interfaces.Services;
+using System.Security.Claims;
+
+namespace SocialMedia.Web.Controllers
+{
+    [Authorize]
+    public class NotificationsController : Controller
+    {
+        private readonly INotificationService _notificationService;
+
+        public NotificationsController(INotificationService notificationService)
+        {
+            _notificationService = notificationService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> List(int take = 20)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var notifications = await _notificationService.GetUserNotificationsAsync(userId, take);
+            return Ok(notifications);
+        }
+    }
+}

--- a/SocialMedia.Web/Controllers/NotificationsController.cs
+++ b/SocialMedia.Web/Controllers/NotificationsController.cs
@@ -24,5 +24,18 @@ namespace SocialMedia.Web.Controllers
             var notifications = await _notificationService.GetUserNotificationsAsync(userId, take);
             return Ok(notifications);
         }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> MarkAsRead(Guid id)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var updated = await _notificationService.MarkAsReadAsync(userId, id);
+            if (!updated) return NotFound();
+
+            return Ok(new { success = true });
+        }
     }
 }

--- a/SocialMedia.Web/Controllers/NotificationsController.cs
+++ b/SocialMedia.Web/Controllers/NotificationsController.cs
@@ -37,5 +37,16 @@ namespace SocialMedia.Web.Controllers
 
             return Ok(new { success = true });
         }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> MarkAllAsRead()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var updatedCount = await _notificationService.MarkAllAsReadAsync(userId);
+            return Ok(new { success = true, updatedCount });
+        }
     }
 }

--- a/SocialMedia.Web/Hubs/NotificationHub.cs
+++ b/SocialMedia.Web/Hubs/NotificationHub.cs
@@ -18,19 +18,4 @@ public class NotificationHub : Hub
 
         await base.OnConnectedAsync();
     }
-
-    /// <summary>
-    /// Push a notification to a specific user from a server-side service (via IHubContext).
-    /// Not typically called directly by clients.
-    /// </summary>
-    public async Task NotifyUser(string targetUserId, string type, string message, string? actionUrl = null)
-    {
-        await Clients.Group(targetUserId).SendAsync("ReceiveNotification", new
-        {
-            type,
-            message,
-            actionUrl,
-            createdAt = DateTime.UtcNow
-        });
-    }
 }

--- a/SocialMedia.Web/Program.cs
+++ b/SocialMedia.Web/Program.cs
@@ -8,6 +8,7 @@ using SocialMedia.Domain.Entities;
 using SocialMedia.Infrastructure.Data;
 using SocialMedia.Infrastructure.Repositories;
 using SocialMedia.Web.Hubs;
+using SocialMedia.Web.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -48,6 +49,7 @@ builder.Services.AddScoped<IPostService, PostService>();
 builder.Services.AddScoped<IReactionService, ReactionService>();
 builder.Services.AddScoped<ICommentService, CommentService>();
 builder.Services.AddScoped<IDashboardService, DashboardService>();
+builder.Services.AddScoped<INotificationRealtimeService, NotificationRealtimeService>();
 builder.Services.AddSignalR();
 
 var app = builder.Build();

--- a/SocialMedia.Web/Program.cs
+++ b/SocialMedia.Web/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddScoped<IReactionService, ReactionService>();
 builder.Services.AddScoped<ICommentService, CommentService>();
 builder.Services.AddScoped<IDashboardService, DashboardService>();
 builder.Services.AddScoped<INotificationRealtimeService, NotificationRealtimeService>();
+builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddSignalR();
 
 var app = builder.Build();

--- a/SocialMedia.Web/Services/NotificationRealtimeService.cs
+++ b/SocialMedia.Web/Services/NotificationRealtimeService.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.SignalR;
+using SocialMedia.Application.Interfaces.Services;
+using SocialMedia.Domain.Enums;
+using SocialMedia.Web.Hubs;
+
+namespace SocialMedia.Web.Services
+{
+    public class NotificationRealtimeService : INotificationRealtimeService
+    {
+        private readonly IHubContext<NotificationHub> _hubContext;
+
+        public NotificationRealtimeService(IHubContext<NotificationHub> hubContext)
+        {
+            _hubContext = hubContext;
+        }
+
+        public async Task PushAsync(string targetUserId, NotificationType type, string message, string? actionUrl = null)
+        {
+            await _hubContext.Clients.Group(targetUserId).SendAsync("ReceiveNotification", new
+            {
+                type = type.ToString(),
+                message,
+                actionUrl,
+                createdAt = DateTime.UtcNow
+            });
+        }
+    }
+}

--- a/SocialMedia.Web/Services/NotificationRealtimeService.cs
+++ b/SocialMedia.Web/Services/NotificationRealtimeService.cs
@@ -14,14 +14,21 @@ namespace SocialMedia.Web.Services
             _hubContext = hubContext;
         }
 
-        public async Task PushAsync(string targetUserId, NotificationType type, string message, string? actionUrl = null)
+        public async Task PushAsync(
+            string targetUserId,
+            NotificationType type,
+            string message,
+            string? actionUrl = null,
+            Guid? notificationId = null,
+            DateTime? createdAt = null)
         {
             await _hubContext.Clients.Group(targetUserId).SendAsync("ReceiveNotification", new
             {
+                id = notificationId,
                 type = type.ToString(),
                 message,
                 actionUrl,
-                createdAt = DateTime.UtcNow
+                createdAt = createdAt ?? DateTime.UtcNow
             });
         }
     }

--- a/SocialMedia.Web/Views/Notifications/Index.cshtml
+++ b/SocialMedia.Web/Views/Notifications/Index.cshtml
@@ -1,0 +1,233 @@
+@{
+    ViewData["Title"] = "Notifications";
+}
+
+<div class="container py-4">
+    <div class="card bg-dark border-secondary text-light">
+        <div class="card-header border-secondary d-flex justify-content-between align-items-center">
+            <h4 class="mb-0">Notifications</h4>
+            <button id="notifications-page-mark-all-btn" type="button" class="btn btn-sm btn-outline-light">Mark all as read</button>
+        </div>
+        <div id="notifications-page-list" class="card-body p-0">
+            <div class="px-3 py-3 text-muted small">Loading...</div>
+        </div>
+        <div class="card-footer border-secondary bg-dark">
+            <button id="notifications-page-load-more-btn" type="button" class="btn btn-outline-light w-100">Load more</button>
+        </div>
+    </div>
+</div>
+
+<form id="notificationsPageAntiForgeryForm" class="d-none">
+    @Html.AntiForgeryToken()
+</form>
+
+@section Scripts {
+    <script>
+        (() => {
+            const listEl = document.getElementById('notifications-page-list');
+            const loadMoreBtn = document.getElementById('notifications-page-load-more-btn');
+            const markAllBtn = document.getElementById('notifications-page-mark-all-btn');
+
+            let items = [];
+            let skip = 0;
+            const take = 20;
+            let hasMore = true;
+            let loading = false;
+
+            function escapeHtml(text) {
+                return String(text ?? '')
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+            }
+
+            function relativeTime(dateInput) {
+                const date = new Date(dateInput);
+                const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+                if (Number.isNaN(seconds)) return '';
+                if (seconds < 60) return 'Just now';
+                const minutes = Math.floor(seconds / 60);
+                if (minutes < 60) return `${minutes}m ago`;
+                const hours = Math.floor(minutes / 60);
+                if (hours < 24) return `${hours}h ago`;
+                const days = Math.floor(hours / 24);
+                if (days < 7) return `${days}d ago`;
+                return date.toLocaleDateString();
+            }
+
+            function notificationTypeLabel(type) {
+                if (typeof type === 'string') return type;
+                const map = {
+                    1: 'FriendRequest',
+                    2: 'Message',
+                    3: 'PostReaction',
+                    4: 'Comment',
+                    5: 'GroupInvitation'
+                };
+                return map[type] ?? 'Notification';
+            }
+
+            function notificationIcon(type) {
+                const label = notificationTypeLabel(type);
+                switch (label) {
+                    case 'Message': return 'fa-envelope';
+                    case 'Comment': return 'fa-comment';
+                    case 'PostReaction': return 'fa-heart';
+                    case 'FriendRequest': return 'fa-user-plus';
+                    default: return 'fa-bell';
+                }
+            }
+
+            function unreadCount() {
+                return items.filter(n => !n.isRead).length;
+            }
+
+            function getAntiForgeryToken() {
+                return document.querySelector('#notificationsPageAntiForgeryForm input[name="__RequestVerificationToken"]')?.value
+                    || document.querySelector('input[name="__RequestVerificationToken"]')?.value
+                    || '';
+            }
+
+            function updateButtons() {
+                if (!loadMoreBtn || !markAllBtn) return;
+                loadMoreBtn.disabled = loading || !hasMore;
+                loadMoreBtn.textContent = loading ? 'Loading...' : 'Load more';
+                loadMoreBtn.style.display = hasMore && items.length > 0 ? 'inline-block' : 'none';
+
+                const unread = unreadCount();
+                markAllBtn.disabled = unread === 0;
+                markAllBtn.style.opacity = unread === 0 ? '0.6' : '1';
+            }
+
+            function render() {
+                if (!listEl) return;
+                if (!items.length) {
+                    listEl.innerHTML = '<div class="px-3 py-3 text-muted small">No notifications yet.</div>';
+                    updateButtons();
+                    return;
+                }
+
+                listEl.innerHTML = items.map(n => `
+                    <button type="button" class="w-100 text-start px-3 py-3 border-0 border-bottom border-secondary bg-transparent text-light notification-page-item ${n.isRead ? '' : 'bg-black'}" data-id="${n.id}" data-action-url="${escapeHtml(n.actionUrl ?? '')}">
+                        <div class="d-flex align-items-start gap-2">
+                            <div class="mt-1"><i class="fas ${notificationIcon(n.type)} text-primary"></i></div>
+                            <div class="flex-grow-1">
+                                <div class="small fw-semibold">${escapeHtml(n.content)}</div>
+                                <div class="small text-muted">${relativeTime(n.createdAt)}</div>
+                            </div>
+                            ${n.isRead ? '' : '<span class="badge bg-primary rounded-pill" style="font-size:0.55rem;">new</span>'}
+                        </div>
+                    </button>
+                `).join('');
+
+                updateButtons();
+            }
+
+            async function loadNotifications() {
+                if (loading) return;
+                loading = true;
+                updateButtons();
+
+                try {
+                    const res = await fetch(`/Notifications/List?take=${take}&skip=${skip}`);
+                    if (!res.ok) return;
+                    const data = await res.json();
+
+                    if (skip === 0) {
+                        items = data;
+                    } else {
+                        const existing = new Set(items.map(n => String(n.id)));
+                        items = [...items, ...data.filter(n => !existing.has(String(n.id)))];
+                    }
+
+                    hasMore = data.length === take;
+                    render();
+                } catch {
+                    if (listEl) {
+                        listEl.innerHTML = '<div class="px-3 py-3 text-danger small">Failed to load notifications.</div>';
+                    }
+                } finally {
+                    loading = false;
+                    updateButtons();
+                }
+            }
+
+            async function markAsRead(id) {
+                if (!id) return false;
+                const item = items.find(n => String(n.id) === String(id));
+                if (!item) return false;
+                if (item.isRead) return true;
+
+                item.isRead = true;
+                render();
+
+                try {
+                    const token = getAntiForgeryToken();
+                    const fd = new FormData();
+                    fd.append('id', id);
+                    fd.append('__RequestVerificationToken', token);
+
+                    const res = await fetch('/Notifications/MarkAsRead', { method: 'POST', body: fd });
+                    if (!res.ok) {
+                        item.isRead = false;
+                        render();
+                        return false;
+                    }
+                    return true;
+                } catch {
+                    item.isRead = false;
+                    render();
+                    return false;
+                }
+            }
+
+            async function markAllAsRead() {
+                if (unreadCount() === 0) return;
+
+                const previous = items.map(n => ({ ...n }));
+                items = items.map(n => ({ ...n, isRead: true }));
+                render();
+
+                try {
+                    const token = getAntiForgeryToken();
+                    const fd = new FormData();
+                    fd.append('__RequestVerificationToken', token);
+
+                    const res = await fetch('/Notifications/MarkAllAsRead', { method: 'POST', body: fd });
+                    if (!res.ok) {
+                        items = previous;
+                        render();
+                    }
+                } catch {
+                    items = previous;
+                    render();
+                }
+            }
+
+            loadMoreBtn?.addEventListener('click', () => {
+                if (loading || !hasMore) return;
+                skip += take;
+                loadNotifications();
+            });
+
+            listEl?.addEventListener('click', async (e) => {
+                const target = e.target instanceof HTMLElement ? e.target.closest('.notification-page-item') : null;
+                if (!target) return;
+                const id = target.getAttribute('data-id');
+                const actionUrl = target.getAttribute('data-action-url');
+                if (id) {
+                    const ok = await markAsRead(id);
+                    if (ok && actionUrl) {
+                        window.location.href = actionUrl;
+                    }
+                }
+            });
+
+            markAllBtn?.addEventListener('click', markAllAsRead);
+
+            loadNotifications();
+        })();
+    </script>
+}

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -243,10 +243,34 @@
                             var user = await userManager.FindByNameAsync(User.Identity.Name);
                             var profilePic = user?.ProfilePictureUrl ?? "/images/user.jpg";
 
+                            <li class="nav-item dropdown position-relative d-none d-lg-block">
+                                <a class="nav-circle-btn text-decoration-none" href="#" id="navbarNotificationsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="Notifications">
+                                    <i class="fas fa-bell"></i>
+                                    <span id="notif-badge-desktop" class="badge bg-danger rounded-circle position-absolute" style="top: -2px; right: -5px; font-size: 0.65rem; display:none;">0</span>
+                                </a>
+                                <div class="dropdown-menu dropdown-menu-end dropdown-menu-dark-fb mt-2 p-0" aria-labelledby="navbarNotificationsDropdown" style="width: 360px;">
+                                    <div class="px-3 py-2 border-bottom border-secondary d-flex justify-content-between align-items-center">
+                                        <span class="fw-bold">Notifications</span>
+                                        <small class="text-muted">Live</small>
+                                    </div>
+                                    <div id="notif-list-desktop" style="max-height: 360px; overflow-y: auto;">
+                                        <div class="px-3 py-3 text-muted small">Loading...</div>
+                                    </div>
+                                </div>
+                            </li>
+
                             <li class="nav-item position-relative d-none d-lg-block">
                                 <a class="nav-circle-btn text-decoration-none" asp-controller="Messaging" asp-action="Index" title="Messages">
                                     <i class="fas fa-envelope"></i>
                                     <span id="msg-badge-desktop" class="badge bg-danger rounded-circle position-absolute" style="top: -2px; right: -5px; font-size: 0.65rem; display:none;">0</span>
+                                </a>
+                            </li>
+
+                            <li class="nav-item d-lg-none">
+                                <a class="nav-icon-link" href="#" title="Notifications">
+                                    <i class="fas fa-bell"></i>
+                                    <span class="ms-3 fs-6">Notifications</span>
+                                    <span id="notif-badge-mobile" class="badge bg-danger ms-2 rounded-pill" style="display:none;">0</span>
                                 </a>
                             </li>
 
@@ -325,6 +349,7 @@
 
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/search.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
@@ -352,6 +377,137 @@
             }
             refreshMsgBadge();
             setInterval(refreshMsgBadge, 30000); // refresh every 30 seconds
+
+            // ── Notifications list + badge ────────────────────────────────────
+            const notifListDesktop = document.getElementById('notif-list-desktop');
+            const notifBadgeDesktop = document.getElementById('notif-badge-desktop');
+            const notifBadgeMobile = document.getElementById('notif-badge-mobile');
+            let notificationItems = [];
+
+            function escapeHtml(text) {
+                return String(text ?? '')
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+            }
+
+            function relativeTime(dateInput) {
+                const date = new Date(dateInput);
+                const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+                if (Number.isNaN(seconds)) return '';
+                if (seconds < 60) return 'Just now';
+                const minutes = Math.floor(seconds / 60);
+                if (minutes < 60) return `${minutes}m ago`;
+                const hours = Math.floor(minutes / 60);
+                if (hours < 24) return `${hours}h ago`;
+                const days = Math.floor(hours / 24);
+                if (days < 7) return `${days}d ago`;
+                return date.toLocaleDateString();
+            }
+
+            function notificationTypeLabel(type) {
+                if (typeof type === 'string') return type;
+                const map = {
+                    1: 'FriendRequest',
+                    2: 'Message',
+                    3: 'PostReaction',
+                    4: 'Comment',
+                    5: 'GroupInvitation'
+                };
+                return map[type] ?? 'Notification';
+            }
+
+            function notificationIcon(type) {
+                const label = notificationTypeLabel(type);
+                switch (label) {
+                    case 'Message': return 'fa-envelope';
+                    case 'Comment': return 'fa-comment';
+                    case 'PostReaction': return 'fa-heart';
+                    case 'FriendRequest': return 'fa-user-plus';
+                    default: return 'fa-bell';
+                }
+            }
+
+            function updateNotificationBadges() {
+                const unread = notificationItems.filter(n => !n.isRead).length;
+                if (notifBadgeDesktop) {
+                    notifBadgeDesktop.textContent = unread;
+                    notifBadgeDesktop.style.display = unread > 0 ? 'inline-block' : 'none';
+                }
+                if (notifBadgeMobile) {
+                    notifBadgeMobile.textContent = unread;
+                    notifBadgeMobile.style.display = unread > 0 ? 'inline-block' : 'none';
+                }
+            }
+
+            function renderNotificationList() {
+                if (!notifListDesktop) return;
+
+                if (!notificationItems.length) {
+                    notifListDesktop.innerHTML = '<div class="px-3 py-3 text-muted small">No notifications yet.</div>';
+                    return;
+                }
+
+                notifListDesktop.innerHTML = notificationItems.map(n => `
+                    <div class="px-3 py-2 border-bottom border-secondary ${n.isRead ? '' : 'bg-dark'}">
+                        <div class="d-flex align-items-start gap-2">
+                            <div class="mt-1"><i class="fas ${notificationIcon(n.type)} text-primary"></i></div>
+                            <div class="flex-grow-1">
+                                <div class="small fw-semibold">${escapeHtml(n.content)}</div>
+                                <div class="small text-muted">${relativeTime(n.createdAt)}</div>
+                            </div>
+                            ${n.isRead ? '' : '<span class="badge bg-primary rounded-pill" style="font-size:0.55rem;">new</span>'}
+                        </div>
+                    </div>
+                `).join('');
+            }
+
+            async function loadNotifications() {
+                try {
+                    const res = await fetch('/Notifications/List?take=20');
+                    if (!res.ok) return;
+                    notificationItems = await res.json();
+                    renderNotificationList();
+                    updateNotificationBadges();
+                } catch {
+                    if (notifListDesktop) {
+                        notifListDesktop.innerHTML = '<div class="px-3 py-3 text-danger small">Failed to load notifications.</div>';
+                    }
+                }
+            }
+
+            function prependRealtimeNotification(payload) {
+                const item = {
+                    id: crypto.randomUUID ? crypto.randomUUID() : String(Date.now()),
+                    type: payload.type,
+                    content: payload.message,
+                    isRead: false,
+                    createdAt: payload.createdAt ?? new Date().toISOString(),
+                    senderId: null,
+                    senderName: 'Unknown',
+                    senderProfilePictureUrl: null
+                };
+                notificationItems = [item, ...notificationItems].slice(0, 20);
+                renderNotificationList();
+                updateNotificationBadges();
+            }
+
+            loadNotifications();
+
+            // ── NotificationHub realtime listener ─────────────────────────────
+            const notificationConnection = new signalR.HubConnectionBuilder()
+                .withUrl('/notificationhub')
+                .withAutomaticReconnect()
+                .build();
+
+            notificationConnection.on('ReceiveNotification', (payload) => {
+                if (!payload || !payload.message) return;
+                prependRealtimeNotification(payload);
+            });
+
+            notificationConnection.start().catch(() => {});
         </script>
     }
 </body>

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -267,7 +267,7 @@
                             </li>
 
                             <li class="nav-item d-lg-none">
-                                <a class="nav-icon-link" href="#" title="Notifications">
+                                <a class="nav-icon-link" href="#" title="Notifications" data-bs-toggle="offcanvas" data-bs-target="#mobileNotificationsOffcanvas" aria-controls="mobileNotificationsOffcanvas">
                                     <i class="fas fa-bell"></i>
                                     <span class="ms-3 fs-6">Notifications</span>
                                     <span id="notif-badge-mobile" class="badge bg-danger ms-2 rounded-pill" style="display:none;">0</span>
@@ -343,6 +343,24 @@
         </nav>
     </header>
 
+    @if (User.Identity != null && User.Identity.IsAuthenticated)
+    {
+        <div class="offcanvas offcanvas-end text-bg-dark" tabindex="-1" id="mobileNotificationsOffcanvas" aria-labelledby="mobileNotificationsOffcanvasLabel">
+            <div class="offcanvas-header border-bottom border-secondary">
+                <h5 class="offcanvas-title" id="mobileNotificationsOffcanvasLabel">Notifications</h5>
+                <div class="d-flex align-items-center gap-3">
+                    <button id="notif-mark-all-mobile-btn" type="button" class="btn btn-link p-0 text-decoration-none small" style="color:#2d88ff;">Mark all as read</button>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </div>
+            </div>
+            <div class="offcanvas-body p-0">
+                <div id="notif-list-mobile" style="max-height: calc(100vh - 80px); overflow-y: auto;">
+                    <div class="px-3 py-3 text-muted small">Loading...</div>
+                </div>
+            </div>
+        </div>
+    }
+
     <div class="container" style="padding-top: 80px;">
         <main role="main" class="pb-3">
             @RenderBody()
@@ -383,9 +401,11 @@
 
             // ── Notifications list + badge ────────────────────────────────────
             const notifListDesktop = document.getElementById('notif-list-desktop');
+            const notifListMobile = document.getElementById('notif-list-mobile');
             const notifBadgeDesktop = document.getElementById('notif-badge-desktop');
             const notifBadgeMobile = document.getElementById('notif-badge-mobile');
             const notifMarkAllBtn = document.getElementById('notif-mark-all-btn');
+            const notifMarkAllMobileBtn = document.getElementById('notif-mark-all-mobile-btn');
             let notificationItems = [];
 
             function escapeHtml(text) {
@@ -440,8 +460,7 @@
                 }
             }
 
-            function updateNotificationBadges() {
-                const unread = notificationItems.filter(n => !n.isRead).length;
+            function applyUnreadCount(unread) {
                 if (notifBadgeDesktop) {
                     notifBadgeDesktop.textContent = unread;
                     notifBadgeDesktop.style.display = unread > 0 ? 'inline-block' : 'none';
@@ -456,17 +475,31 @@
                     notifMarkAllBtn.style.opacity = unread === 0 ? '0.5' : '1';
                     notifMarkAllBtn.style.pointerEvents = unread === 0 ? 'none' : 'auto';
                 }
+
+                if (notifMarkAllMobileBtn) {
+                    notifMarkAllMobileBtn.disabled = unread === 0;
+                    notifMarkAllMobileBtn.style.opacity = unread === 0 ? '0.5' : '1';
+                    notifMarkAllMobileBtn.style.pointerEvents = unread === 0 ? 'none' : 'auto';
+                }
+            }
+
+            function updateNotificationBadges() {
+                const unread = notificationItems.filter(n => !n.isRead).length;
+                applyUnreadCount(unread);
             }
 
             function renderNotificationList() {
-                if (!notifListDesktop) return;
-
                 if (!notificationItems.length) {
-                    notifListDesktop.innerHTML = '<div class="px-3 py-3 text-muted small">No notifications yet.</div>';
+                    if (notifListDesktop) {
+                        notifListDesktop.innerHTML = '<div class="px-3 py-3 text-muted small">No notifications yet.</div>';
+                    }
+                    if (notifListMobile) {
+                        notifListMobile.innerHTML = '<div class="px-3 py-3 text-muted small">No notifications yet.</div>';
+                    }
                     return;
                 }
 
-                notifListDesktop.innerHTML = notificationItems.map(n => `
+                const html = notificationItems.map(n => `
                     <button type="button" class="w-100 text-start px-3 py-2 border-0 border-bottom border-secondary bg-transparent notification-item ${n.isRead ? '' : 'bg-dark'}" data-notification-id="${n.id}">
                         <div class="d-flex align-items-start gap-2">
                             <div class="mt-1"><i class="fas ${notificationIcon(n.type)} text-primary"></i></div>
@@ -478,6 +511,13 @@
                         </div>
                     </button>
                 `).join('');
+
+                if (notifListDesktop) {
+                    notifListDesktop.innerHTML = html;
+                }
+                if (notifListMobile) {
+                    notifListMobile.innerHTML = html;
+                }
             }
 
             async function loadNotifications() {
@@ -491,7 +531,19 @@
                     if (notifListDesktop) {
                         notifListDesktop.innerHTML = '<div class="px-3 py-3 text-danger small">Failed to load notifications.</div>';
                     }
+                    if (notifListMobile) {
+                        notifListMobile.innerHTML = '<div class="px-3 py-3 text-danger small">Failed to load notifications.</div>';
+                    }
                 }
+            }
+
+            async function refreshNotificationBadgesLight() {
+                try {
+                    const res = await fetch('/Notifications/UnreadCount');
+                    if (!res.ok) return;
+                    const data = await res.json();
+                    applyUnreadCount(data.count ?? 0);
+                } catch { /* ignore network errors */ }
             }
 
             function prependRealtimeNotification(payload) {
@@ -579,6 +631,8 @@
             }
 
             loadNotifications();
+            refreshNotificationBadgesLight();
+            setInterval(refreshNotificationBadgesLight, 30000);
 
             // ── NotificationHub realtime listener ─────────────────────────────
             const notificationConnection = new signalR.HubConnectionBuilder()
@@ -602,7 +656,20 @@
                 }
             });
 
+            notifListMobile?.addEventListener('click', (e) => {
+                const target = e.target instanceof HTMLElement ? e.target.closest('.notification-item') : null;
+                if (!target) return;
+                const id = target.getAttribute('data-notification-id');
+                if (id) {
+                    markNotificationAsRead(id);
+                }
+            });
+
             notifMarkAllBtn?.addEventListener('click', () => {
+                markAllNotificationsAsRead();
+            });
+
+            notifMarkAllMobileBtn?.addEventListener('click', () => {
                 markAllNotificationsAsRead();
             });
         </script>

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -407,6 +407,8 @@
             const notifMarkAllBtn = document.getElementById('notif-mark-all-btn');
             const notifMarkAllMobileBtn = document.getElementById('notif-mark-all-mobile-btn');
             let notificationItems = [];
+            let notifSkip = 0;
+            const notifTake = 20;
 
             function escapeHtml(text) {
                 return String(text ?? '')
@@ -522,9 +524,18 @@
 
             async function loadNotifications() {
                 try {
-                    const res = await fetch('/Notifications/List?take=20');
+                    const res = await fetch(`/Notifications/List?take=${notifTake}&skip=${notifSkip}`);
                     if (!res.ok) return;
-                    notificationItems = await res.json();
+
+                    const items = await res.json();
+                    if (notifSkip === 0) {
+                        notificationItems = items;
+                    } else {
+                        const existingIds = new Set(notificationItems.map(n => String(n.id)));
+                        const newItems = items.filter(n => !existingIds.has(String(n.id)));
+                        notificationItems = [...notificationItems, ...newItems];
+                    }
+
                     renderNotificationList();
                     updateNotificationBadges();
                 } catch {
@@ -671,6 +682,18 @@
 
             notifMarkAllMobileBtn?.addEventListener('click', () => {
                 markAllNotificationsAsRead();
+            });
+
+            const desktopDropdown = document.getElementById('navbarNotificationsDropdown');
+            desktopDropdown?.addEventListener('shown.bs.dropdown', () => {
+                notifSkip = 0;
+                loadNotifications();
+            });
+
+            const mobileOffcanvas = document.getElementById('mobileNotificationsOffcanvas');
+            mobileOffcanvas?.addEventListener('show.bs.offcanvas', () => {
+                notifSkip = 0;
+                loadNotifications();
             });
         </script>
     }

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -365,6 +365,8 @@
                 </div>
             </div>
         </div>
+
+        <div id="notif-toast-container" class="toast-container position-fixed top-0 end-0 p-3" style="z-index: 1200;"></div>
     }
 
     <div class="container" style="padding-top: 80px;">
@@ -414,10 +416,9 @@
             const notifMarkAllMobileBtn = document.getElementById('notif-mark-all-mobile-btn');
             const notifLoadMoreBtn = document.getElementById('notif-load-more-btn');
             const notifLoadMoreMobileBtn = document.getElementById('notif-load-more-mobile-btn');
+            const notifToastContainer = document.getElementById('notif-toast-container');
             let notificationItems = [];
-            let notifSkip = 0;
-            const notifTake = 20;
-            let notifHasMore = true;
+            const notifTake = 5;
             let notifLoading = false;
 
             function escapeHtml(text) {
@@ -501,18 +502,15 @@
             }
 
             function updateLoadMoreButtons() {
-                const show = notifHasMore && notificationItems.length > 0;
-                const text = notifLoading ? 'Loading...' : 'Load more';
+                const show = notificationItems.length >= notifTake;
 
                 if (notifLoadMoreBtn) {
-                    notifLoadMoreBtn.textContent = text;
-                    notifLoadMoreBtn.disabled = notifLoading || !show;
+                    notifLoadMoreBtn.disabled = false;
                     notifLoadMoreBtn.style.display = show ? 'inline-block' : 'none';
                 }
 
                 if (notifLoadMoreMobileBtn) {
-                    notifLoadMoreMobileBtn.textContent = text;
-                    notifLoadMoreMobileBtn.disabled = notifLoading || !show;
+                    notifLoadMoreMobileBtn.disabled = false;
                     notifLoadMoreMobileBtn.style.display = show ? 'inline-block' : 'none';
                 }
             }
@@ -555,19 +553,11 @@
                 updateLoadMoreButtons();
 
                 try {
-                    const res = await fetch(`/Notifications/List?take=${notifTake}&skip=${notifSkip}`);
+                    const res = await fetch(`/Notifications/List?take=${notifTake}&skip=0`);
                     if (!res.ok) return;
 
                     const items = await res.json();
-                    if (notifSkip === 0) {
-                        notificationItems = items;
-                    } else {
-                        const existingIds = new Set(notificationItems.map(n => String(n.id)));
-                        const newItems = items.filter(n => !existingIds.has(String(n.id)));
-                        notificationItems = [...notificationItems, ...newItems];
-                    }
-
-                    notifHasMore = items.length === notifTake;
+                    notificationItems = items;
                     renderNotificationList();
                     updateNotificationBadges();
                 } catch {
@@ -604,13 +594,40 @@
                     senderName: 'Unknown',
                     senderProfilePictureUrl: null
                 };
-                notificationItems = [item, ...notificationItems].slice(0, 20);
+                notificationItems = [item, ...notificationItems].slice(0, notifTake);
                 renderNotificationList();
                 updateNotificationBadges();
+                showRealtimeNotificationToast(item);
 
                 if (!payload.id) {
                     setTimeout(loadNotifications, 1000);
                 }
+            }
+
+            function showRealtimeNotificationToast(notification) {
+                if (!notifToastContainer || !window.bootstrap?.Toast) return;
+
+                const toastEl = document.createElement('div');
+                toastEl.className = 'toast text-bg-dark border border-secondary';
+                toastEl.setAttribute('role', 'alert');
+                toastEl.setAttribute('aria-live', 'assertive');
+                toastEl.setAttribute('aria-atomic', 'true');
+                toastEl.innerHTML = `
+                    <div class="toast-header bg-dark text-light border-secondary">
+                        <i class="fas ${notificationIcon(notification.type)} text-primary me-2"></i>
+                        <strong class="me-auto">New notification</strong>
+                        <small class="text-muted">now</small>
+                        <button type="button" class="btn-close btn-close-white ms-2" data-bs-dismiss="toast" aria-label="Close"></button>
+                    </div>
+                    <div class="toast-body">
+                        ${escapeHtml(notification.content)}
+                    </div>
+                `;
+
+                notifToastContainer.appendChild(toastEl);
+                const toast = new bootstrap.Toast(toastEl, { delay: 5000 });
+                toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
+                toast.show();
             }
 
             async function markNotificationAsRead(notificationId) {
@@ -734,28 +751,20 @@
             });
 
             notifLoadMoreBtn?.addEventListener('click', () => {
-                if (notifLoading || !notifHasMore) return;
-                notifSkip += notifTake;
-                loadNotifications();
+                window.location.href = '/Notifications';
             });
 
             notifLoadMoreMobileBtn?.addEventListener('click', () => {
-                if (notifLoading || !notifHasMore) return;
-                notifSkip += notifTake;
-                loadNotifications();
+                window.location.href = '/Notifications';
             });
 
             const desktopDropdown = document.getElementById('navbarNotificationsDropdown');
             desktopDropdown?.addEventListener('shown.bs.dropdown', () => {
-                notifSkip = 0;
-                notifHasMore = true;
                 loadNotifications();
             });
 
             const mobileOffcanvas = document.getElementById('mobileNotificationsOffcanvas');
             mobileOffcanvas?.addEventListener('show.bs.offcanvas', () => {
-                notifSkip = 0;
-                notifHasMore = true;
                 loadNotifications();
             });
         </script>

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -502,7 +502,7 @@
                 }
 
                 const html = notificationItems.map(n => `
-                    <button type="button" class="w-100 text-start px-3 py-2 border-0 border-bottom border-secondary bg-transparent notification-item ${n.isRead ? '' : 'bg-dark'}" data-notification-id="${n.id}">
+                    <button type="button" class="w-100 text-start px-3 py-2 border-0 border-bottom border-secondary bg-transparent notification-item ${n.isRead ? '' : 'bg-dark'}" data-notification-id="${n.id}" data-action-url="${escapeHtml(n.actionUrl ?? '')}">
                         <div class="d-flex align-items-start gap-2">
                             <div class="mt-1"><i class="fas ${notificationIcon(n.type)} text-primary"></i></div>
                             <div class="flex-grow-1">
@@ -562,6 +562,7 @@
                     id: payload.id ?? (crypto.randomUUID ? crypto.randomUUID() : String(Date.now())),
                     type: payload.type,
                     content: payload.message,
+                    actionUrl: payload.actionUrl ?? '',
                     isRead: false,
                     createdAt: payload.createdAt ?? new Date().toISOString(),
                     senderId: null,
@@ -578,10 +579,11 @@
             }
 
             async function markNotificationAsRead(notificationId) {
-                if (!notificationId) return;
+                if (!notificationId) return false;
 
                 const notification = notificationItems.find(n => String(n.id) === String(notificationId));
-                if (!notification || notification.isRead) return;
+                if (!notification) return false;
+                if (notification.isRead) return true;
 
                 notification.isRead = true;
                 renderNotificationList();
@@ -602,12 +604,16 @@
                         notification.isRead = false;
                         renderNotificationList();
                         updateNotificationBadges();
+                        return false;
                     }
                 } catch {
                     notification.isRead = false;
                     renderNotificationList();
                     updateNotificationBadges();
+                    return false;
                 }
+
+                return true;
             }
 
             async function markAllNotificationsAsRead() {
@@ -658,21 +664,29 @@
 
             notificationConnection.start().catch(() => {});
 
-            notifListDesktop?.addEventListener('click', (e) => {
+            notifListDesktop?.addEventListener('click', async (e) => {
                 const target = e.target instanceof HTMLElement ? e.target.closest('.notification-item') : null;
                 if (!target) return;
                 const id = target.getAttribute('data-notification-id');
+                const actionUrl = target.getAttribute('data-action-url');
                 if (id) {
-                    markNotificationAsRead(id);
+                    const ok = await markNotificationAsRead(id);
+                    if (ok && actionUrl) {
+                        window.location.href = actionUrl;
+                    }
                 }
             });
 
-            notifListMobile?.addEventListener('click', (e) => {
+            notifListMobile?.addEventListener('click', async (e) => {
                 const target = e.target instanceof HTMLElement ? e.target.closest('.notification-item') : null;
                 if (!target) return;
                 const id = target.getAttribute('data-notification-id');
+                const actionUrl = target.getAttribute('data-action-url');
                 if (id) {
-                    markNotificationAsRead(id);
+                    const ok = await markNotificationAsRead(id);
+                    if (ok && actionUrl) {
+                        window.location.href = actionUrl;
+                    }
                 }
             });
 

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -283,6 +283,9 @@
                             </li>
 
                             <li class="nav-item dropdown w-100 w-lg-auto border-top border-secondary d-lg-block pt-2 pt-lg-0 mt-2 mt-lg-0 pb-3 pb-lg-0">
+                                <form id="notificationsAntiForgeryForm" class="d-none">
+                                    @Html.AntiForgeryToken()
+                                </form>
                                 <a class="nav-link d-flex align-items-center gap-2 p-1 pe-2 rounded-pill hover-bg-dark text-decoration-none" href="#" id="navbarProfileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" style="background-color: transparent;">
                                     <img src="@profilePic" class="rounded-circle" style="width:36px; height:36px; object-fit:cover; border: 1px solid #393a3b;" />
                                     <span class="fw-bold text-light" style="font-size: 0.95rem;">@User.Identity.Name</span>
@@ -419,6 +422,12 @@
                 return map[type] ?? 'Notification';
             }
 
+            function getAntiForgeryToken() {
+                return document.querySelector('#notificationsAntiForgeryForm input[name="__RequestVerificationToken"]')?.value
+                    || document.querySelector('input[name="__RequestVerificationToken"]')?.value
+                    || '';
+            }
+
             function notificationIcon(type) {
                 const label = notificationTypeLabel(type);
                 switch (label) {
@@ -451,7 +460,7 @@
                 }
 
                 notifListDesktop.innerHTML = notificationItems.map(n => `
-                    <div class="px-3 py-2 border-bottom border-secondary ${n.isRead ? '' : 'bg-dark'}">
+                    <button type="button" class="w-100 text-start px-3 py-2 border-0 border-bottom border-secondary bg-transparent notification-item ${n.isRead ? '' : 'bg-dark'}" data-notification-id="${n.id}">
                         <div class="d-flex align-items-start gap-2">
                             <div class="mt-1"><i class="fas ${notificationIcon(n.type)} text-primary"></i></div>
                             <div class="flex-grow-1">
@@ -460,7 +469,7 @@
                             </div>
                             ${n.isRead ? '' : '<span class="badge bg-primary rounded-pill" style="font-size:0.55rem;">new</span>'}
                         </div>
-                    </div>
+                    </button>
                 `).join('');
             }
 
@@ -492,6 +501,40 @@
                 notificationItems = [item, ...notificationItems].slice(0, 20);
                 renderNotificationList();
                 updateNotificationBadges();
+                setTimeout(loadNotifications, 1000);
+            }
+
+            async function markNotificationAsRead(notificationId) {
+                if (!notificationId) return;
+
+                const notification = notificationItems.find(n => String(n.id) === String(notificationId));
+                if (!notification || notification.isRead) return;
+
+                notification.isRead = true;
+                renderNotificationList();
+                updateNotificationBadges();
+
+                try {
+                    const token = getAntiForgeryToken();
+                    const fd = new FormData();
+                    fd.append('id', notificationId);
+                    fd.append('__RequestVerificationToken', token);
+
+                    const res = await fetch('/Notifications/MarkAsRead', {
+                        method: 'POST',
+                        body: fd
+                    });
+
+                    if (!res.ok) {
+                        notification.isRead = false;
+                        renderNotificationList();
+                        updateNotificationBadges();
+                    }
+                } catch {
+                    notification.isRead = false;
+                    renderNotificationList();
+                    updateNotificationBadges();
+                }
             }
 
             loadNotifications();
@@ -508,6 +551,15 @@
             });
 
             notificationConnection.start().catch(() => {});
+
+            notifListDesktop?.addEventListener('click', (e) => {
+                const target = e.target instanceof HTMLElement ? e.target.closest('.notification-item') : null;
+                if (!target) return;
+                const id = target.getAttribute('data-notification-id');
+                if (id) {
+                    markNotificationAsRead(id);
+                }
+            });
         </script>
     }
 </body>

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -450,6 +450,12 @@
                     notifBadgeMobile.textContent = unread;
                     notifBadgeMobile.style.display = unread > 0 ? 'inline-block' : 'none';
                 }
+
+                if (notifMarkAllBtn) {
+                    notifMarkAllBtn.disabled = unread === 0;
+                    notifMarkAllBtn.style.opacity = unread === 0 ? '0.5' : '1';
+                    notifMarkAllBtn.style.pointerEvents = unread === 0 ? 'none' : 'auto';
+                }
             }
 
             function renderNotificationList() {
@@ -490,7 +496,7 @@
 
             function prependRealtimeNotification(payload) {
                 const item = {
-                    id: crypto.randomUUID ? crypto.randomUUID() : String(Date.now()),
+                    id: payload.id ?? (crypto.randomUUID ? crypto.randomUUID() : String(Date.now())),
                     type: payload.type,
                     content: payload.message,
                     isRead: false,
@@ -502,7 +508,10 @@
                 notificationItems = [item, ...notificationItems].slice(0, 20);
                 renderNotificationList();
                 updateNotificationBadges();
-                setTimeout(loadNotifications, 1000);
+
+                if (!payload.id) {
+                    setTimeout(loadNotifications, 1000);
+                }
             }
 
             async function markNotificationAsRead(notificationId) {

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -251,7 +251,7 @@
                                 <div class="dropdown-menu dropdown-menu-end dropdown-menu-dark-fb mt-2 p-0" aria-labelledby="navbarNotificationsDropdown" style="width: 360px;">
                                     <div class="px-3 py-2 border-bottom border-secondary d-flex justify-content-between align-items-center">
                                         <span class="fw-bold">Notifications</span>
-                                        <small class="text-muted">Live</small>
+                                        <button id="notif-mark-all-btn" type="button" class="btn btn-link p-0 text-decoration-none small" style="color:#2d88ff;">Mark all as read</button>
                                     </div>
                                     <div id="notif-list-desktop" style="max-height: 360px; overflow-y: auto;">
                                         <div class="px-3 py-3 text-muted small">Loading...</div>
@@ -385,6 +385,7 @@
             const notifListDesktop = document.getElementById('notif-list-desktop');
             const notifBadgeDesktop = document.getElementById('notif-badge-desktop');
             const notifBadgeMobile = document.getElementById('notif-badge-mobile');
+            const notifMarkAllBtn = document.getElementById('notif-mark-all-btn');
             let notificationItems = [];
 
             function escapeHtml(text) {
@@ -537,6 +538,37 @@
                 }
             }
 
+            async function markAllNotificationsAsRead() {
+                const unreadItems = notificationItems.filter(n => !n.isRead);
+                if (unreadItems.length === 0) return;
+
+                const prevState = notificationItems.map(n => ({ ...n }));
+                notificationItems = notificationItems.map(n => ({ ...n, isRead: true }));
+                renderNotificationList();
+                updateNotificationBadges();
+
+                try {
+                    const token = getAntiForgeryToken();
+                    const fd = new FormData();
+                    fd.append('__RequestVerificationToken', token);
+
+                    const res = await fetch('/Notifications/MarkAllAsRead', {
+                        method: 'POST',
+                        body: fd
+                    });
+
+                    if (!res.ok) {
+                        notificationItems = prevState;
+                        renderNotificationList();
+                        updateNotificationBadges();
+                    }
+                } catch {
+                    notificationItems = prevState;
+                    renderNotificationList();
+                    updateNotificationBadges();
+                }
+            }
+
             loadNotifications();
 
             // ── NotificationHub realtime listener ─────────────────────────────
@@ -559,6 +591,10 @@
                 if (id) {
                     markNotificationAsRead(id);
                 }
+            });
+
+            notifMarkAllBtn?.addEventListener('click', () => {
+                markAllNotificationsAsRead();
             });
         </script>
     }

--- a/SocialMedia.Web/Views/Shared/_Layout.cshtml
+++ b/SocialMedia.Web/Views/Shared/_Layout.cshtml
@@ -256,6 +256,9 @@
                                     <div id="notif-list-desktop" style="max-height: 360px; overflow-y: auto;">
                                         <div class="px-3 py-3 text-muted small">Loading...</div>
                                     </div>
+                                    <div class="px-3 py-2 border-top border-secondary text-center">
+                                        <button id="notif-load-more-btn" type="button" class="btn btn-sm btn-outline-light w-100">Load more</button>
+                                    </div>
                                 </div>
                             </li>
 
@@ -357,6 +360,9 @@
                 <div id="notif-list-mobile" style="max-height: calc(100vh - 80px); overflow-y: auto;">
                     <div class="px-3 py-3 text-muted small">Loading...</div>
                 </div>
+                <div class="px-3 py-2 border-top border-secondary text-center">
+                    <button id="notif-load-more-mobile-btn" type="button" class="btn btn-sm btn-outline-light w-100">Load more</button>
+                </div>
             </div>
         </div>
     }
@@ -406,9 +412,13 @@
             const notifBadgeMobile = document.getElementById('notif-badge-mobile');
             const notifMarkAllBtn = document.getElementById('notif-mark-all-btn');
             const notifMarkAllMobileBtn = document.getElementById('notif-mark-all-mobile-btn');
+            const notifLoadMoreBtn = document.getElementById('notif-load-more-btn');
+            const notifLoadMoreMobileBtn = document.getElementById('notif-load-more-mobile-btn');
             let notificationItems = [];
             let notifSkip = 0;
             const notifTake = 20;
+            let notifHasMore = true;
+            let notifLoading = false;
 
             function escapeHtml(text) {
                 return String(text ?? '')
@@ -490,6 +500,23 @@
                 applyUnreadCount(unread);
             }
 
+            function updateLoadMoreButtons() {
+                const show = notifHasMore && notificationItems.length > 0;
+                const text = notifLoading ? 'Loading...' : 'Load more';
+
+                if (notifLoadMoreBtn) {
+                    notifLoadMoreBtn.textContent = text;
+                    notifLoadMoreBtn.disabled = notifLoading || !show;
+                    notifLoadMoreBtn.style.display = show ? 'inline-block' : 'none';
+                }
+
+                if (notifLoadMoreMobileBtn) {
+                    notifLoadMoreMobileBtn.textContent = text;
+                    notifLoadMoreMobileBtn.disabled = notifLoading || !show;
+                    notifLoadMoreMobileBtn.style.display = show ? 'inline-block' : 'none';
+                }
+            }
+
             function renderNotificationList() {
                 if (!notificationItems.length) {
                     if (notifListDesktop) {
@@ -523,6 +550,10 @@
             }
 
             async function loadNotifications() {
+                if (notifLoading) return;
+                notifLoading = true;
+                updateLoadMoreButtons();
+
                 try {
                     const res = await fetch(`/Notifications/List?take=${notifTake}&skip=${notifSkip}`);
                     if (!res.ok) return;
@@ -536,6 +567,7 @@
                         notificationItems = [...notificationItems, ...newItems];
                     }
 
+                    notifHasMore = items.length === notifTake;
                     renderNotificationList();
                     updateNotificationBadges();
                 } catch {
@@ -545,6 +577,9 @@
                     if (notifListMobile) {
                         notifListMobile.innerHTML = '<div class="px-3 py-3 text-danger small">Failed to load notifications.</div>';
                     }
+                } finally {
+                    notifLoading = false;
+                    updateLoadMoreButtons();
                 }
             }
 
@@ -698,15 +733,29 @@
                 markAllNotificationsAsRead();
             });
 
+            notifLoadMoreBtn?.addEventListener('click', () => {
+                if (notifLoading || !notifHasMore) return;
+                notifSkip += notifTake;
+                loadNotifications();
+            });
+
+            notifLoadMoreMobileBtn?.addEventListener('click', () => {
+                if (notifLoading || !notifHasMore) return;
+                notifSkip += notifTake;
+                loadNotifications();
+            });
+
             const desktopDropdown = document.getElementById('navbarNotificationsDropdown');
             desktopDropdown?.addEventListener('shown.bs.dropdown', () => {
                 notifSkip = 0;
+                notifHasMore = true;
                 loadNotifications();
             });
 
             const mobileOffcanvas = document.getElementById('mobileNotificationsOffcanvas');
             mobileOffcanvas?.addEventListener('show.bs.offcanvas', () => {
                 notifSkip = 0;
+                notifHasMore = true;
                 loadNotifications();
             });
         </script>


### PR DESCRIPTION
This pull request delivers the full notifications feature for authenticated users: persist notifications in the database, expose read/list APIs, and surface them in the UI with real-time updates.

Backend & data

Create notifications for post reactions (likes), comments, friend requests (follow), and direct messages.
Store notifications with read state and support listing with pagination (skip / take).
Add an unread-count endpoint for lightweight badge refresh.
Support marking a single notification as read and marking all as read (with CSRF protection on mutating endpoints).
Real-time

Push new notifications over SignalR with stable server-issued IDs, timestamps, optional action URLs, and resilient, non-blocking delivery (failures are logged without failing the main operation).
Restrict the hub so clients cannot broadcast arbitrary notifications (server-only push paths).
Frontend / UX

Desktop dropdown and mobile offcanvas for a short preview (latest items).
Toast-style popup (5s) when a live notification arrives, in addition to badge updates.
Dedicated Notifications page for the full list, “load more” pagination, mark-as-read on click (with navigation via per-type action URLs where applicable), and mark-all-as-read.
Closes

Closes #13 